### PR TITLE
Osx arm64 fixes

### DIFF
--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -1,0 +1,10 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+channel_sources:
+- napari/label/bundle_tools_2,conda-forge
+channel_targets:
+- napari bundle_tools_2
+macos_machine:
+- arm64-apple-darwin20.0.0
+target_platform:
+- osx-arm64

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -8,7 +8,7 @@ done
 
 # `base` conda might use sigtool, which ships a codesign binary that shadows Apple's one
 # pyinstaller expects that one first in PATH
-if [[ $target_platform == "osx-64" ]]; then
+if [[ $target_platform = "osx-"* ]]; then
   ln -s /usr/bin/codesign "$BUILD_PREFIX/bin/codesign"
 fi
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set version = "22.9.0.post1" %}
 {% set menuinst_version = "2.0a" %}
 {% set constructor_version = "3.3.1" %}
-{% set python_version = "3.10.6" %}
+{% set python_version = "3.9.13" %}
 
 package:
   name: conda-standalone
@@ -37,8 +37,10 @@ requirements:
     - constructor >=4.0b2
 test:
   commands:
+    - export CONDA_SOLVER="classic"  # [unix]
     - ${PREFIX}/standalone_conda/conda.exe -V    # [unix]
     - ${PREFIX}/standalone_conda/conda.exe create -y -p ./env_test zlib tqdm    # [unix]
+    - set "CONDA_SOLVER=classic"  # [win]
     - '%PREFIX%\standalone_conda\conda.exe -V'    # [win]
     - '%PREFIX%\standalone_conda\conda.exe create -y -p env_test zlib tqdm'    # [win]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ source:
     folder: constructor
 
 build:
-  number: 0
+  number: 1
   ignore_run_exports:
     - '*'
 


### PR DESCRIPTION
Python 3.10 crashes on local builds, but 3.9 doesn't, so let's sync.